### PR TITLE
Add pip cache step to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,14 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -31,6 +39,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Build Docker image
         run: docker build -t profticket_bot_image .


### PR DESCRIPTION
## Summary
- cache pip dependencies in `flake8` workflow
- cache pip dependencies in `build-test` workflow

## Testing
- `pytest -q`
- *(failure)* `pip install flake8==6.0.0 flake8-isort==6.0.0` (network issue)
