### PR TITLE
Add seat history tracking

### DIFF
--- a/services/profticket/profticket_snapshoter.py
+++ b/services/profticket/profticket_snapshoter.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from services.profticket.profticket_api import ProfticketsInfo
-from telegram.db.models import Show
+from telegram.db.models import Show, ShowSeatHistory
 
 logger = logging.getLogger(__name__)
 timezone = pytz.timezone(settings.DEFAULT_TIMEZONE)
@@ -103,6 +103,14 @@ class ShowUpdateService:
                     index_elements=['id'], set_=show_values
                 )
                 await session.execute(stmt)
+
+                # record seats history
+                hist_stmt = insert(ShowSeatHistory).values(
+                    show_id=event_id,
+                    timestamp=current_time,
+                    seats=show_values['seats'],
+                )
+                await session.execute(hist_stmt)
 
             # Удаляем устаревшие записи
             all_event_ids = list(shows.keys())

--- a/telegram/db/models.py
+++ b/telegram/db/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import BigInteger, Boolean, Column, Integer, String, func
+from sqlalchemy import BigInteger, Boolean, Column, Integer, String, func, ForeignKey
 
 from telegram.db import Base
 
@@ -69,3 +69,12 @@ class Show(Base):
     updated_at = Column(
         Integer
     )  # время последнего обновления (Unix timestamp)
+
+
+class ShowSeatHistory(Base):
+    __tablename__ = 'show_seat_history'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    show_id = Column(String, ForeignKey('shows.id'), nullable=False)
+    timestamp = Column(Integer)
+    seats = Column(Integer)

--- a/tests/test_seat_history.py
+++ b/tests/test_seat_history.py
@@ -1,0 +1,97 @@
+import unittest
+import sys
+import types
+from sqlalchemy import select, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from telegram.db.base import Base
+from telegram.db.models import ShowSeatHistory
+
+aiogram = sys.modules.get('aiogram')
+if aiogram is None:
+    aiogram = types.ModuleType('aiogram')
+    sys.modules['aiogram'] = aiogram
+aiogram.Bot = type('Bot', (), {})
+
+from services.profticket.profticket_snapshoter import ShowUpdateService
+
+
+class DummyProfticket:
+    def __init__(self, data):
+        self.data = data
+
+    def set_date(self, month, year):
+        pass
+
+    async def collect_full_info(self):
+        return self.data
+
+
+class DummyBot:
+    async def send_message(self, *a, **kw):
+        pass
+
+
+class SeatHistoryTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.engine = create_engine('sqlite:///:memory:')
+        Base.metadata.create_all(self.engine)
+        self.sync_maker = sessionmaker(self.engine)
+
+    async def asyncTearDown(self):
+        self.engine.dispose()
+
+    async def test_history_inserted(self):
+        data = {
+            'e1': {
+                'show_id': '1',
+                'theater': 't',
+                'scene': 's',
+                'show_name': 'n',
+                'date': 'd',
+                'duration': '1',
+                'age': '0',
+                'seats': 5,
+                'image': '',
+                'annotation': '',
+                'min_price': 0,
+                'max_price': 0,
+                'pushkin': False,
+                'buy_link': '',
+                'actors': [],
+            }
+        }
+        service = ShowUpdateService(None, DummyProfticket(data), DummyBot())
+
+        sync_session = self.sync_maker()
+
+        class FakeAsyncSession:
+            def __init__(self, session):
+                self._s = session
+
+            async def execute(self, *a, **kw):
+                return self._s.execute(*a, **kw)
+
+            async def commit(self):
+                self._s.commit()
+
+            async def rollback(self):
+                self._s.rollback()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                self._s.close()
+
+        session = FakeAsyncSession(sync_session)
+
+        await service._update_month_data(session, 1, 2024)
+        res = await session.execute(select(ShowSeatHistory))
+        history = res.scalar_one()
+        self.assertEqual(history.show_id, 'e1')
+        self.assertEqual(history.seats, 5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add ShowSeatHistory model
- log seat numbers into history when updating shows
- test seat history recording

## Testing
- `pytest -q`