### PR TITLE
Implement price history tracking

### DIFF
--- a/services/profticket/profticket_snapshoter.py
+++ b/services/profticket/profticket_snapshoter.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from services.profticket.profticket_api import ProfticketsInfo
-from telegram.db.models import Show
+from telegram.db.models import Show, PriceHistory
 
 logger = logging.getLogger(__name__)
 timezone = pytz.timezone(settings.DEFAULT_TIMEZONE)
@@ -65,9 +65,7 @@ class ShowUpdateService:
             current_shows = await session.execute(
                 select(Show).where(Show.month == month, Show.year == year)
             )
-            current_shows_dict = {
-                show.id: show.seats for show in current_shows.scalars()
-            }
+            current_shows_dict = {show.id: show for show in current_shows.scalars()}
 
             # Подготавливаем данные для обновления
             for event_id, show_data in shows.items():
@@ -81,7 +79,11 @@ class ShowUpdateService:
                     'duration': str(show_data['duration']),
                     'age': str(show_data['age']),
                     'seats': int(show_data['seats'] or 0),
-                    'previous_seats': current_shows_dict.get(event_id),
+                    'previous_seats': (
+                        current_shows_dict.get(event_id).seats
+                        if current_shows_dict.get(event_id)
+                        else None
+                    ),
                     'image': show_data['image'],
                     'annotation': show_data['annotation'],
                     'min_price': int(show_data['min_price'] or 0),
@@ -96,6 +98,23 @@ class ShowUpdateService:
                     'year': year,
                     'updated_at': current_time,
                 }
+
+                prev = current_shows_dict.get(event_id)
+                if (
+                    not prev
+                    or prev.min_price != show_values['min_price']
+                    or prev.max_price != show_values['max_price']
+                ):
+                    await session.execute(
+                        insert(PriceHistory).values(
+                            {
+                                'show_id': event_id,
+                                'timestamp': current_time,
+                                'min_price': show_values['min_price'],
+                                'max_price': show_values['max_price'],
+                            }
+                        )
+                    )
 
                 # Используем insert().on_conflict_do_update()
                 stmt = insert(Show).values(show_values)

--- a/telegram/db/models.py
+++ b/telegram/db/models.py
@@ -69,3 +69,14 @@ class Show(Base):
     updated_at = Column(
         Integer
     )  # время последнего обновления (Unix timestamp)
+
+
+class PriceHistory(Base):
+    __tablename__ = 'price_history'
+
+    id = Column(Integer, primary_key=True)
+    show_id = Column(String)
+    timestamp = Column(Integer, default=current_timestamp)
+    min_price = Column(Integer)
+    max_price = Column(Integer)
+

--- a/tests/test_price_history.py
+++ b/tests/test_price_history.py
@@ -1,0 +1,120 @@
+import unittest
+import types
+import sys
+
+sys.modules['aiogram'].Bot = type('Bot', (), {})
+
+from services.profticket.profticket_snapshoter import ShowUpdateService
+from telegram.db.models import Show, PriceHistory
+
+class FakeProfticket:
+    def __init__(self, data):
+        self.data = data
+    def set_date(self, m, y):
+        pass
+    async def collect_full_info(self):
+        return self.data
+
+class Obj:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+class FakeResult:
+    def __init__(self, items):
+        self._items = items
+    def scalars(self):
+        return self._items
+    def scalar(self):
+        return self._items[0] if self._items else None
+
+class FakeSession:
+    def __init__(self):
+        self.shows = {}
+        self.price_history = []
+    async def execute(self, stmt):
+        from sqlalchemy.sql import Select, Delete
+        from sqlalchemy.sql.dml import Insert
+        if isinstance(stmt, Select):
+            table = stmt.get_final_froms()[0].name
+            if table == 'shows':
+                return FakeResult([Obj(**v) for v in self.shows.values()])
+            elif table == 'price_history':
+                return FakeResult([Obj(**v) for v in self.price_history])
+        elif isinstance(stmt, Insert):
+            vals = {k: v for k, v in stmt.compile().params.items() if not k.startswith('param_')}
+            if stmt.table.name == 'shows':
+                self.shows[vals['id']] = vals
+            elif stmt.table.name == 'price_history':
+                self.price_history.append(vals)
+            return FakeResult([])
+        elif isinstance(stmt, Delete):
+            ids = stmt.compile().params.get('id_1', [])
+            for sid in list(self.shows):
+                if sid not in ids:
+                    del self.shows[sid]
+            return FakeResult([])
+        return FakeResult([])
+    async def commit(self):
+        pass
+    async def rollback(self):
+        pass
+
+class PriceHistoryTest(unittest.IsolatedAsyncioTestCase):
+    async def test_record_on_price_change(self):
+        data = {
+            '1': {
+                'show_id': 1,
+                'theater': '',
+                'scene': '',
+                'show_name': 'n',
+                'date': 'd',
+                'duration': '',
+                'age': '',
+                'seats': 0,
+                'image': '',
+                'annotation': '',
+                'min_price': 100,
+                'max_price': 200,
+                'pushkin': False,
+                'buy_link': '',
+                'actors': [],
+            }
+        }
+        session = FakeSession()
+        bot = types.SimpleNamespace(send_message=lambda *a, **kw: None)
+        srv = ShowUpdateService(None, FakeProfticket(data), bot)
+        await srv._update_month_data(session, 5, 2024)
+        data['1']['min_price'] = 150
+        data['1']['max_price'] = 250
+        await srv._update_month_data(session, 5, 2024)
+        self.assertEqual(len(session.price_history), 2)
+
+    async def test_no_duplicate_when_price_same(self):
+        data = {
+            '1': {
+                'show_id': 1,
+                'theater': '',
+                'scene': '',
+                'show_name': 'n',
+                'date': 'd',
+                'duration': '',
+                'age': '',
+                'seats': 0,
+                'image': '',
+                'annotation': '',
+                'min_price': 100,
+                'max_price': 200,
+                'pushkin': False,
+                'buy_link': '',
+                'actors': [],
+            }
+        }
+        session = FakeSession()
+        bot = types.SimpleNamespace(send_message=lambda *a, **kw: None)
+        srv = ShowUpdateService(None, FakeProfticket(data), bot)
+        await srv._update_month_data(session, 5, 2024)
+        await srv._update_month_data(session, 5, 2024)
+        self.assertEqual(len(session.price_history), 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- track price changes with new `PriceHistory` model
- store price history on show update
- test price history logic

## Testing
- `pytest -q`
