### PR TITLE
Improve sold-out prediction logic

### DIFF
--- a/telegram/handlers/analytics_handlers.py
+++ b/telegram/handlers/analytics_handlers.py
@@ -312,9 +312,13 @@ async def cmd_generate_soldout_report(
         return
 
     response_lines = [f'{report_title}{period_text}:']
-    for i, (name, ts, _id) in enumerate(results, 1):
+    for i, (name, ts, _id, show_date) in enumerate(results, 1):
         date_str = format_timestamp_to_date(ts, include_year=True)
-        response_lines.append(f'{i}. {name} — ожидаемый sold out: {date_str}')
+        response_lines.append(
+            LEXICON_RU['PREDICT_SELL_OUT_LINE'].format(
+                index=i, name=name, show_date=show_date, date=date_str
+            )
+        )
     await message.answer('\n'.join(response_lines))
 
 

--- a/telegram/lexicon/lexicon_ru.py
+++ b/telegram/lexicon/lexicon_ru.py
@@ -57,6 +57,7 @@ LEXICON_RU: dict[str, str] = {
     'TOP_SHOWS_SALES_REPORT_TITLE': 'Топ спектаклей по продажам',
     'TOP_SHOWS_SPEED_REPORT_TITLE': 'Топ спектаклей по скорости продаж',
     'PREDICT_SELL_OUT_REPORT_TITLE': 'Прогноз sold out',
+    'PREDICT_SELL_OUT_LINE': '{index}. {name} ({show_date}) — ожидаемый sold out: {date}',
     'NO_DATA_FOR_REPORT': 'Нет данных для формирования отчета за указанный период.',
     'SALES_SPEED_UNIT_PER_DAY': 'бил./день',
     'SOLD_OUT_AT_TIMESTAMP': 'Продано полностью в: ', # Used with datetime


### PR DESCRIPTION
## Summary
- adjust `predict_sold_out` to validate predictions relative to current time
- return show date when predicting soonest sell outs
- show the show date in the sell-out report
- add template line in the lexicon for sold-out reports
- test sold-out prediction against past dates

## Testing
- `pytest -q`