### PR TITLE
Fix analytics for deleted shows

### DIFF
--- a/services/profticket/analytics.py
+++ b/services/profticket/analytics.py
@@ -33,13 +33,9 @@ def filter_data_by_period(
         ]
 
     else:
-        filtered_shows = [
-            s for s in shows if not getattr(s, 'is_deleted', False)
-        ]
+        filtered_shows = list(shows)
         filtered_ids = {s.id for s in filtered_shows}
-        filtered_histories = [
-            h for h in histories if h.show_id in filtered_ids
-        ]
+        filtered_histories = [h for h in histories if h.show_id in filtered_ids]
     buckets = defaultdict(list)
     for h in filtered_histories:
         buckets[h.show_id].append(h)

--- a/tests/test_analytics_utils.py
+++ b/tests/test_analytics_utils.py
@@ -15,23 +15,35 @@ class AnalyticsUtilsTestCase(unittest.TestCase):
         self.shows = [
             Show(id='s1', show_name='Alpha', month=1, year=2024, actors='[]'),
             Show(id='s2', show_name='Beta', month=2, year=2024, actors='[]'),
+            Show(
+                id='s3',
+                show_name='Gamma',
+                month=1,
+                year=2024,
+                actors='[]',
+                is_deleted=True,
+            ),
         ]
         self.histories = [
             ShowSeatHistory(show_id='s1', timestamp=10, seats=10),
             ShowSeatHistory(show_id='s1', timestamp=20, seats=8),
             ShowSeatHistory(show_id='s2', timestamp=10, seats=20),
             ShowSeatHistory(show_id='s2', timestamp=20, seats=15),
+            ShowSeatHistory(show_id='s3', timestamp=10, seats=5),
+            ShowSeatHistory(show_id='s3', timestamp=20, seats=0),
         ]
 
     def test_filter_data_by_period_all(self):
         filtered_shows, buckets = filter_data_by_period(
             self.shows, self.histories, None, None
         )
-        self.assertEqual(len(filtered_shows), 2)
+        self.assertEqual(len(filtered_shows), 3)
         self.assertIn('s1', buckets)
         self.assertIn('s2', buckets)
+        self.assertIn('s3', buckets)
         self.assertEqual(len(buckets['s1']), 2)
         self.assertEqual(len(buckets['s2']), 2)
+        self.assertEqual(len(buckets['s3']), 2)
 
     def test_filter_data_by_period_month(self):
         filtered_shows, buckets = filter_data_by_period(
@@ -42,6 +54,7 @@ class AnalyticsUtilsTestCase(unittest.TestCase):
         # Теперь bucket всегда содержит все истории для show_id
         self.assertIn('s1', buckets)
         self.assertEqual(len(buckets['s1']), 2)
+        self.assertNotIn('s3', buckets)
 
     def test_parse_show_date(self):
         dt = parse_show_date('2024-07-01 19:00')

--- a/tests/test_seat_history.py
+++ b/tests/test_seat_history.py
@@ -205,6 +205,41 @@ class SeatHistoryTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(top_month1[0], ('Show Alpha', 5, 's1'))
         self.assertEqual(top_month1[1], ('Show Beta', 3, 's2'))
 
+    def test_top_shows_by_sales_includes_deleted_all_time(self):
+        shows_data = [
+            Show(
+                id='s1',
+                show_name='Show Alpha',
+                month=1,
+                year=2024,
+                actors='[]',
+                is_deleted=True,
+            ),
+            Show(
+                id='s2',
+                show_name='Show Beta',
+                month=1,
+                year=2024,
+                actors='[]',
+            ),
+        ]
+        histories_data = [
+            ShowSeatHistory(show_id='s1', timestamp=10, seats=10),
+            ShowSeatHistory(show_id='s1', timestamp=20, seats=5),  # sold 5
+            ShowSeatHistory(show_id='s2', timestamp=10, seats=20),
+            ShowSeatHistory(show_id='s2', timestamp=20, seats=18),  # sold 2
+        ]
+
+        top_all_time = analytics.top_shows_by_sales(shows_data, histories_data, n=2)
+        self.assertEqual(top_all_time[0], ('Show Alpha', 5, 's1'))
+        self.assertEqual(top_all_time[1], ('Show Beta', 2, 's2'))
+
+        top_month = analytics.top_shows_by_sales(
+            shows_data, histories_data, month=1, year=2024, n=2
+        )
+        self.assertEqual(len(top_month), 1)
+        self.assertEqual(top_month[0], ('Show Beta', 2, 's2'))
+
     def test_top_artists_by_sales(self):
         shows = [
             Show(


### PR DESCRIPTION
## Summary
- include deleted shows when calculating analytics for all time
- test that filter_data_by_period keeps deleted shows for all time
- test that deleted shows appear in all-time sales top but not in monthly stats

## Testing
- `pytest -q`