### PR TITLE
Fix analytics output formatting

### DIFF
--- a/services/profticket/analytics.py
+++ b/services/profticket/analytics.py
@@ -10,6 +10,17 @@ import pytz
 from config import settings
 from telegram.db.models import Show, ShowSeatHistory
 
+# Common list of titles and awards to ignore when processing actors
+TITLES_TO_SKIP = [
+    'народный артист россии',
+    'народная артистка россии',
+    'заслуженный артист россии',
+    'заслуженная артистка россии',
+    'лауреат государственных премий',
+    'заслуженный деятель искусств',
+    'лауреат премии',
+]
+
 
 # Универсальная фильтрация по периоду и формирование buckets
 def filter_data_by_period(
@@ -264,15 +275,7 @@ def top_artists_by_sales(
             show_total_sales[show.id] = net
 
     # Список титулов, которые нужно пропустить или объединить
-    titles_to_merge = [
-        'народный артист россии',
-        'народная артистка россии',
-        'заслуженный артист россии',
-        'заслуженная артистка россии',
-        'лауреат государственных премий',
-        'заслуженный деятель искусств',
-        'лауреат премии',
-    ]
+    titles_to_merge = TITLES_TO_SKIP
 
     artist_aggregated_sales = defaultdict(int)
 

--- a/telegram/lexicon/lexicon_ru.py
+++ b/telegram/lexicon/lexicon_ru.py
@@ -68,10 +68,10 @@ LEXICON_RU: dict[str, str] = {
     'TOP_SHOWS_RETURNS_REPORT_TITLE': 'Топ спектаклей по возвратам билетов',
     'TOP_SHOWS_RETURN_RATE_REPORT_TITLE': 'Топ спектаклей по проценту возвратов',
     'TOP_SHOWS_SALES_LINE': (
-        '{index}. <b>{name}</b> - продано <b>{sold}</b>{tracking}'
+        '{index}. <b>{name}</b> - продано <b>{sold}</b> бил.{tracking}'
     ),
     'TOP_ARTISTS_SALES_LINE': (
-        '{index}. \U0001F464 <b>{name}</b> — уч. в продажах: <b>{sold}</b> бил.'
+        '{index}. <b>{name}</b> — уч. в продажах: <b>{sold}</b> бил.'
     ),
     'TOP_SHOWS_SPEED_LINE': (
         '{index}. <b>{name}</b> - ~{speed:.1f} {unit}'


### PR DESCRIPTION
## Summary
- unify wording for ticket sales across analytics reports
- remove extra emoji for artists
- show tracking date for artist sales
- reuse titles-to-skip list in analytics service

## Testing
- `isort telegram/handlers/analytics_handlers.py telegram/lexicon/lexicon_ru.py services/profticket/analytics.py`
- `flake8`
- `pytest -q`
