### PR TITLE
Improve analytics message formatting and sold-out prediction

### DIFF
--- a/services/profticket/analytics.py
+++ b/services/profticket/analytics.py
@@ -173,10 +173,6 @@ def predict_sold_out(
         )
         now_ts = int(datetime.now(tz).timestamp())
 
-    # --- Окно последних 24 часов ---
-    WINDOW_HOURS = 24
-    window_start = recs[-1].timestamp - WINDOW_HOURS * 3600
-    recs = [r for r in recs if r.timestamp >= window_start]
     if len(recs) < 3:
         return None
 

--- a/telegram/handlers/analytics_handlers.py
+++ b/telegram/handlers/analytics_handlers.py
@@ -331,7 +331,7 @@ async def cmd_generate_top_report_month(
                 ) + track
             )
     if len(response_lines) > 1:
-        await message.answer('\n'.join(response_lines))
+        await message.answer('\n\n'.join(response_lines))
     else:
         await message.answer(LEXICON_RU['NO_DATA_FOR_REPORT'] + period_text)
 
@@ -402,7 +402,7 @@ async def cmd_generate_soldout_report(
                 index=i, name=name, show_date=show_date, date=date_str
             )
         )
-    await message.answer('\n'.join(response_lines))
+    await message.answer('\n\n'.join(response_lines))
 
 
 # Функция для форматирования timestamp в читаемую дату

--- a/telegram/lexicon/lexicon_ru.py
+++ b/telegram/lexicon/lexicon_ru.py
@@ -57,7 +57,10 @@ LEXICON_RU: dict[str, str] = {
     'TOP_SHOWS_SALES_REPORT_TITLE': 'Топ спектаклей по продажам',
     'TOP_SHOWS_SPEED_REPORT_TITLE': 'Топ спектаклей по скорости продаж',
     'PREDICT_SELL_OUT_REPORT_TITLE': 'Прогноз sold out',
-    'PREDICT_SELL_OUT_LINE': '{index}. {name} ({show_date}) — ожидаемый sold out: {date}',
+    'PREDICT_SELL_OUT_LINE': (
+        '{index}. <b>{name}</b> ({show_date})\n'
+        '   \u23F3 Ожидаемый sold out: {date}'
+    ),
     'NO_DATA_FOR_REPORT': 'Нет данных для формирования отчета за указанный период.',
     'SALES_SPEED_UNIT_PER_DAY': 'бил./день',
     'SOLD_OUT_AT_TIMESTAMP': 'Продано полностью в: ', # Used with datetime
@@ -68,19 +71,24 @@ LEXICON_RU: dict[str, str] = {
     'TOP_SHOWS_RETURNS_REPORT_TITLE': 'Топ спектаклей по возвратам билетов',
     'TOP_SHOWS_RETURN_RATE_REPORT_TITLE': 'Топ спектаклей по проценту возвратов',
     'TOP_SHOWS_SALES_LINE': (
-        '{index}. <b>{name}</b> - продано <b>{sold}</b> бил.{tracking}'
+        '{index}. <b>{name}</b>\n'
+        '   \U0001F39F Продано: <b>{sold}</b> бил.{tracking}'
     ),
     'TOP_ARTISTS_SALES_LINE': (
-        '{index}. <b>{name}</b> — уч. в продажах: <b>{sold}</b> бил.'
+        '{index}. <b>{name}</b>\n'
+        '   \U0001F39F Продаж: <b>{sold}</b> бил.'
     ),
     'TOP_SHOWS_SPEED_LINE': (
-        '{index}. <b>{name}</b> - ~{speed:.1f} {unit}'
+        '{index}. <b>{name}</b>\n'
+        '   \u26A1\ufe0f Скорость: <b>{speed:.1f} {unit}</b>'
     ),
     'TOP_SHOWS_RETURNS_LINE': (
-        '{index}. <b>{name}</b> - возвратов <b>{returns}</b>'
+        '{index}. <b>{name}</b>\n'
+        '   \u21A9\ufe0f Возвратов: <b>{returns}</b>'
     ),
     'TOP_SHOWS_RETURN_RATE_LINE': (
-        '{index}. <b>{name}</b> - возвратов <b>{percent:.1f}%</b>'
+        '{index}. <b>{name}</b>\n'
+        '   \u21A9\ufe0f Возвратов: <b>{percent:.1f}%</b>'
     ),
     'TRACKING_SINCE': ' с {date}г.',
 }


### PR DESCRIPTION
## Summary
- format analytics results with emojis and blank lines
- use the entire history to predict sold out, removing the 24‑hour window

## Testing
- `isort services/profticket/analytics.py telegram/handlers/analytics_handlers.py telegram/lexicon/lexicon_ru.py`
- `flake8`
- `pytest -q`
