### PR TITLE
Fix analytics tests after API changes

### DIFF
--- a/tests/test_analytics_utils.py
+++ b/tests/test_analytics_utils.py
@@ -1,14 +1,18 @@
 import unittest
 from datetime import datetime
 
-from services.profticket.analytics import (_calculate_real_sales_from_history,
-                                           _calculate_returns_from_history,
-                                           _calculate_show_sales_from_history,
-                                           _get_show_details,
-                                           calendar_pace_dashboard,
+from services.profticket.analytics import (calendar_pace_dashboard,
                                            filter_data_by_period,
+                                           get_net_sales_and_returns,
                                            parse_show_date)
 from telegram.db.models import Show, ShowSeatHistory
+
+
+def old_calc_sales(history):
+    if len(history) < 2:
+        return 0
+    diff = history[0].seats - history[-1].seats
+    return diff if diff > 0 else 0
 
 
 class AnalyticsUtilsTestCase(unittest.TestCase):
@@ -38,13 +42,13 @@ class AnalyticsUtilsTestCase(unittest.TestCase):
         filtered_shows, buckets = filter_data_by_period(
             self.shows, self.histories, None, None
         )
-        self.assertEqual(len(filtered_shows), 3)
+        # Deleted shows are excluded by default
+        self.assertEqual(len(filtered_shows), 2)
         self.assertIn('s1', buckets)
         self.assertIn('s2', buckets)
-        self.assertIn('s3', buckets)
+        self.assertNotIn('s3', buckets)
         self.assertEqual(len(buckets['s1']), 2)
         self.assertEqual(len(buckets['s2']), 2)
-        self.assertEqual(len(buckets['s3']), 2)
 
     def test_filter_data_by_period_month(self):
         filtered_shows, buckets = filter_data_by_period(
@@ -64,38 +68,33 @@ class AnalyticsUtilsTestCase(unittest.TestCase):
         self.assertIsInstance(dt2, datetime)
         self.assertIsNone(parse_show_date('not a date'))
 
-    def test_get_show_details(self):
-        show = _get_show_details('s1', self.shows)
-        self.assertIsNotNone(show)
-        self.assertEqual(show.show_name, 'Alpha')
-        self.assertIsNone(_get_show_details('nope', self.shows))
-
     def test_calculate_show_sales_from_history(self):
         # 10 -> 8, sold 2
-        sales = _calculate_show_sales_from_history(
+        sold, returned = get_net_sales_and_returns(
             [
                 ShowSeatHistory(show_id='s1', timestamp=10, seats=10),
                 ShowSeatHistory(show_id='s1', timestamp=20, seats=8),
             ]
         )
-        self.assertEqual(sales, 2)
+        self.assertEqual(sold, 2)
+        self.assertEqual(returned, 0)
+
         # Only one record
-        self.assertEqual(
-            _calculate_show_sales_from_history(
-                [ShowSeatHistory(show_id='s1', timestamp=10, seats=10)]
-            ),
-            0,
+        sold, returned = get_net_sales_and_returns(
+            [ShowSeatHistory(show_id='s1', timestamp=10, seats=10)]
         )
+        self.assertEqual(sold, 0)
+        self.assertEqual(returned, 0)
+
         # No sales (seats increased)
-        self.assertEqual(
-            _calculate_show_sales_from_history(
-                [
-                    ShowSeatHistory(show_id='s1', timestamp=10, seats=8),
-                    ShowSeatHistory(show_id='s1', timestamp=20, seats=10),
-                ]
-            ),
-            0,
+        sold, returned = get_net_sales_and_returns(
+            [
+                ShowSeatHistory(show_id='s1', timestamp=10, seats=8),
+                ShowSeatHistory(show_id='s1', timestamp=20, seats=10),
+            ]
         )
+        self.assertEqual(sold, 0)
+        self.assertEqual(returned, 2)
 
     def test_calculate_real_sales_with_returns(self):
         # Сценарий с возвратами - должен считать все продажи
@@ -112,12 +111,12 @@ class AnalyticsUtilsTestCase(unittest.TestCase):
             ),  # Продано ещё 10
         ]
         # Старый метод (разница начала и конца): 100 - 85 = 15
-        old_method = _calculate_show_sales_from_history(history)
+        old_method = old_calc_sales(history)
         self.assertEqual(old_method, 15)
 
-        # Новый метод (суммирование всех интервалов продаж): 10 + 10 = 20
-        real_sales = _calculate_real_sales_from_history(history)
-        self.assertEqual(real_sales, 20)
+        sold, returned = get_net_sales_and_returns(history)
+        self.assertEqual(sold, 20)  # 10 + 10
+        self.assertEqual(returned, 5)
 
     def test_calculate_real_sales_only_returns(self):
         # Сценарий только с возвратами
@@ -131,12 +130,12 @@ class AnalyticsUtilsTestCase(unittest.TestCase):
             ),  # Возврат ещё 5
         ]
         # Старый метод: отрицательная разница, вернёт 0
-        old_method = _calculate_show_sales_from_history(history)
+        old_method = old_calc_sales(history)
         self.assertEqual(old_method, 0)
 
-        # Новый метод: нет продаж, только возвраты
-        real_sales = _calculate_real_sales_from_history(history)
-        self.assertEqual(real_sales, 0)
+        sold, returned = get_net_sales_and_returns(history)
+        self.assertEqual(sold, 0)
+        self.assertEqual(returned, 15)
 
     def test_calculate_real_sales_complex_pattern(self):
         # Сложный пример: продажи-возвраты-продажи-возвраты
@@ -155,12 +154,12 @@ class AnalyticsUtilsTestCase(unittest.TestCase):
             ),  # Продано 10
         ]
         # Старый метод: 100 - 80 = 20
-        old_method = _calculate_show_sales_from_history(history)
+        old_method = old_calc_sales(history)
         self.assertEqual(old_method, 20)
 
-        # Новый метод: 10 + 10 + 10 = 30
-        real_sales = _calculate_real_sales_from_history(history)
-        self.assertEqual(real_sales, 30)
+        sold, returned = get_net_sales_and_returns(history)
+        self.assertEqual(sold, 30)  # 10 + 10 + 10
+        self.assertEqual(returned, 10)
 
     def test_calculate_returns(self):
         # Сценарий с возвратами
@@ -177,9 +176,9 @@ class AnalyticsUtilsTestCase(unittest.TestCase):
             ),  # Продано ещё 10
         ]
 
-        # Функция должна подсчитать только возвраты: 5
-        returns = _calculate_returns_from_history(history)
-        self.assertEqual(returns, 5)
+        sold, returned = get_net_sales_and_returns(history)
+        self.assertEqual(sold, 20)
+        self.assertEqual(returned, 5)
 
     def test_calculate_returns_only_returns(self):
         # Сценарий только с возвратами
@@ -193,8 +192,9 @@ class AnalyticsUtilsTestCase(unittest.TestCase):
             ),  # Возврат ещё 5
         ]
 
-        returns = _calculate_returns_from_history(history)
-        self.assertEqual(returns, 15)  # 10 + 5
+        sold, returned = get_net_sales_and_returns(history)
+        self.assertEqual(sold, 0)
+        self.assertEqual(returned, 15)  # 10 + 5
 
     def test_calculate_returns_complex(self):
         # Сложный сценарий: продажи-возвраты-продажи-возвраты
@@ -213,17 +213,13 @@ class AnalyticsUtilsTestCase(unittest.TestCase):
             ),  # Продано 10
         ]
 
-        returns = _calculate_returns_from_history(history)
-        self.assertEqual(returns, 10)  # 5 + 5
-
-        # Проверяем, что продажи и возвраты считаются правильно
-        sales = _calculate_real_sales_from_history(history)
-        self.assertEqual(sales, 30)  # 10 + 10 + 10
+        sold, returned = get_net_sales_and_returns(history)
+        self.assertEqual(returned, 10)  # 5 + 5
+        self.assertEqual(sold, 30)  # 10 + 10 + 10
 
         net_change = history[0].seats - history[-1].seats
-        self.assertEqual(
-            net_change, sales - returns
-        )  # 100 - 80 = 30 - 10 = 20
+        # 100 - 80 = 30 - 10 = 20
+        self.assertEqual(net_change, sold - returned)
 
     def test_calendar_pace_dashboard_with_n_parameter(self):
         """Тест что функция calendar_pace_dashboard


### PR DESCRIPTION
## Summary
- update analytics tests to use new helpers
- align seat history tests with updated analytics API

## Testing
- `flake8 tests/test_analytics_utils.py tests/test_seat_history.py`
- `pytest -q`